### PR TITLE
Opal 1233 dask resource paramterization

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,25 @@ client = MongoClient('example.com',
 
 By default mongosh excludes all db.auth() operations from the saved history
 
+## Dask Gateway
+
+### Modifying Resource Limits
+
+Inorder to modify resource limits for dask gateway you will need to configure the values in the dask gateway helm chart values. Currently, by default they should be configured to allow the scheduler and workers 2 G of memory and one core a piece with the cluster total limits being 10 G of memory with 6 cores and 6 workers as a maximum. These values can be located at:
+- gateway
+  - extraConfig (This is where the cluster limits are defined)
+  - backend
+  
+    - scheduler
+    
+      - cores
+      - memory
+    
+    - worker
+    
+      - cores
+      - memory
+
 ## TODO
 add the regcred-init repo to opal-helm
 add the argoCD repo to opal-helm

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -117,9 +117,9 @@ gateway:
   # `values.yaml` files, but is unnecessary in other cases.
   extraConfig:
     resourceLimits: |
-      c.ClusterConfig.cluster_max_cores = 5
-      c.ClusterConfig.cluster_max_memory = "10 G"
-      c.ClusterConfig.cluster_max_workers = 5
+      c.KubeClusterConfig.cluster_max_cores = 5
+      c.KubeClusterConfig.cluster_max_memory = "10 G"
+      c.KubeClusterConfig.cluster_max_workers = 5
 
   # backend nested configuration relates to the scheduler and worker resources
   # created for DaskCluster k8s resources by the controller.

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -148,7 +148,7 @@ gateway:
       # Cores request/limit for the scheduler.
       cores:
         request: 1
-        limit: 10
+        limit: 5
 
       # Memory request/limit for the scheduler.
       memory:
@@ -166,13 +166,13 @@ gateway:
 
       # Cores request/limit for each worker.
       cores:
-        request:
-        limit:
+        request: 1
+        limit: 1
 
       # Memory request/limit for each worker.
       memory:
-        request:
-        limit:
+        request: "2 G"
+        limit: "4 G"
 
       # Number of threads available for a worker. Sets
       # `c.KubeClusterConfig.worker_threads`

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -152,12 +152,12 @@ gateway:
       # Cores request/limit for the scheduler.
       cores:
         request: 1
-        limit: 6
+        limit: 1
 
       # Memory request/limit for the scheduler.
       memory:
         request: "2 G"
-        limit: "12 G"
+        limit: "2 G"
 
     worker:
       # Any extra configuration for the worker pod. Sets

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -147,8 +147,8 @@ gateway:
 
       # Cores request/limit for the scheduler.
       cores:
-        request: "1"
-        limit: "10"
+        request: 1
+        limit: 10
 
       # Memory request/limit for the scheduler.
       memory:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -147,13 +147,13 @@ gateway:
 
       # Cores request/limit for the scheduler.
       cores:
-        request:
-        limit:
+        request: "1"
+        limit: "10"
 
       # Memory request/limit for the scheduler.
       memory:
-        request:
-        limit:
+        request: "2 G"
+        limit: "10 G"
 
     worker:
       # Any extra configuration for the worker pod. Sets

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -117,9 +117,9 @@ gateway:
   # `values.yaml` files, but is unnecessary in other cases.
   extraConfig:
     resourceLimits: |
-      c.KubeClusterConfig.cluster_max_cores = 5
+      c.KubeClusterConfig.cluster_max_cores = 6
       c.KubeClusterConfig.cluster_max_memory = "10 G"
-      c.KubeClusterConfig.cluster_max_workers = 5
+      c.KubeClusterConfig.cluster_max_workers = 6
 
   # backend nested configuration relates to the scheduler and worker resources
   # created for DaskCluster k8s resources by the controller.
@@ -152,12 +152,12 @@ gateway:
       # Cores request/limit for the scheduler.
       cores:
         request: 1
-        limit: 5
+        limit: 6
 
       # Memory request/limit for the scheduler.
       memory:
         request: "2 G"
-        limit: "10 G"
+        limit: "12 G"
 
     worker:
       # Any extra configuration for the worker pod. Sets
@@ -176,7 +176,7 @@ gateway:
       # Memory request/limit for each worker.
       memory:
         request: "2 G"
-        limit: "4 G"
+        limit: "2 G"
 
       # Number of threads available for a worker. Sets
       # `c.KubeClusterConfig.worker_threads`

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -117,8 +117,9 @@ gateway:
   # `values.yaml` files, but is unnecessary in other cases.
   extraConfig:
     resourceLimits: |
-      c.ClusterConfig.cluster_max_cores = 10
+      c.ClusterConfig.cluster_max_cores = 5
       c.ClusterConfig.cluster_max_memory = "10 G"
+      c.ClusterConfig.cluster_max_workers = 5
 
   # backend nested configuration relates to the scheduler and worker resources
   # created for DaskCluster k8s resources by the controller.

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -115,7 +115,10 @@ gateway:
   # (code-blocks are run in alphabetical order by key, the key value itself is
   # meaningless). The map version is useful as it supports merging multiple
   # `values.yaml` files, but is unnecessary in other cases.
-  extraConfig: {}
+  extraConfig:
+    resourceLimits: |
+      c.ClusterConfig.cluster_max_cores = 10
+      c.ClusterConfig.cluster_max_memory = "10 G"
 
   # backend nested configuration relates to the scheduler and worker resources
   # created for DaskCluster k8s resources by the controller.

--- a/opal-setup/values.yaml
+++ b/opal-setup/values.yaml
@@ -29,7 +29,7 @@ valuesFile: test-values.yaml
 
 source: &appSource
   url: "https://github.com/309thEDDGE/opal-helm.git"
-  targetRevision: "OPAL-1229-dask-argo"
+  targetRevision: "OPAL-1233-dask-resource-paramterization"
 
 appValues:
   source: *appSource


### PR DESCRIPTION
for testing purposes I was this dask code which would typically break for me in previous attempts without the resource limits.

Cell 1
```
from dask_gateway import Gateway
import time
from dask.distributed import Client
import dask.array as da

gateway = Gateway("http://<URL>", auth="jupyterhub")
cluster = gateway.new_cluster()
cluster.adapt(minimum=2, maximum=4)
client = Client(cluster)
client
x = da.random.random(size=(300_000, 300_000), chunks=1000)
```

Cell 2
```
%%time
m = client.submit(x.mean)
me = client.gather(m)
print(float(me))
```

Cell 3
```
cluster.shutdown()
```

I did notice that when I bumped the array size up to 3,000,000 x 3,000,000 it would still stall everything on my machine and but eventually it would come back without me having to shutdown and spin opal back up. Not sure if this is a cause of concern or not.