### PR TITLE
updated NGINX package list with the psycopg2-binary

### DIFF
--- a/apps/jupyterhub/templates/jupyterhub-config-local-channel.yaml
+++ b/apps/jupyterhub/templates/jupyterhub-config-local-channel.yaml
@@ -48,6 +48,8 @@ data:
       - pip==24.0
       - plotly==5.19.0
       - pyarrow==15.0.0
+      - psycopg2==2.9.9
+      - psycopg2-binary==2.9.9
       - pytest==8.0.2
       - pytest-cov==4.1.0
       - python=3.11.7
@@ -64,5 +66,4 @@ data:
       - widgetsnbextension==4.0.10
       - pymongo==4.6.2
       - ruff==0.3.0
-      - psycopg2==2.9.9
       - sqlalchemy==2.0.28

--- a/apps/nginx/values.yaml
+++ b/apps/nginx/values.yaml
@@ -20,7 +20,7 @@ image:
 condaChannelImage:
   registry: registry1.dso.mil
   repository: ironbank/opensource/metrostar/pytorch
-  tag: cuda_v4
+  tag: cuda_v5
   pullPolicy: IfNotPresent
   
 imagePullSecrets: 

--- a/opal-setup/values.yaml
+++ b/opal-setup/values.yaml
@@ -1,6 +1,6 @@
 # leave these empty to disable them in the rendered app yamls
-argoProject: &argoProj ""
-appPrefix: &appPrefix ""
+argoProject: &argoProj "test"
+appPrefix: &appPrefix "test"
 
 namespaces:
   - &minioNS minio-tenant
@@ -37,7 +37,7 @@ valuesFile: test-values.yaml
 
 source: &appSource
   url: "https://github.com/309thEDDGE/opal-helm.git"
-  targetRevision: "aks-comp-rebase-test"
+  targetRevision: "OPAL-591"
 
 # Most of this is just propagating settings from above, but change as needed for your use case
 appValues:


### PR DESCRIPTION
This should update the automatic NGINX packages with psycopg2-binary package that is associated with the pytorch image.  Testing should include spinning up a local instance of the OPAL-helm when the pytorch image has be uploaded to registry1.dso.mil