### PR TITLE
Opal 652

### DIFF
--- a/apps/keycloak/Chart.yaml
+++ b/apps/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
-version: 1.1
+version: v1.1
 appVersion: 25.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/apps/keycloak/Chart.yaml
+++ b/apps/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloak
-version: 18.4.3-bb.2
-appVersion: 21.1.1
+version: 1.1
+appVersion: 25.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
   - sso
@@ -20,7 +20,7 @@ icon: https://www.keycloak.org/resources/images/keycloak_icon_512px.svg
 annotations:
   helm.sh/images: |
     - name: keycloak
-      image: registry1.dso.mil/ironbank/opensource/keycloak/keycloak:21.1.1
+      image: registry1.dso.mil/ironbank/opensource/keycloak/keycloak:25.0.5
 #    - name: postgresl12
 #      condition: postgresql.enabled
 #      image: registry1.dso.mil/ironbank/opensource/postgres/postgresql12:12.15

--- a/apps/keycloak/templates/service-metrics.yaml
+++ b/apps/keycloak/templates/service-metrics.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,8 +12,9 @@ spec:
   clusterIP: None
   ports:
     - name: http-internal
-      port: 9000
+      port: {{ .Values.metrics.port | default "9000" }}
       targetPort: http-internal
       protocol: TCP
   selector:
     {{- include "keycloak.selectorLabels" . | nindent 4}}
+{{- end }}

--- a/apps/keycloak/templates/service-metrics.yaml
+++ b/apps/keycloak/templates/service-metrics.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keycloak.fullname" . }}-metrics
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-internal
+      port: 9000
+      targetPort: http-internal
+      protocol: TCP
+  selector:
+    {{- include "keycloak.selectorLabels" . | nindent 4}}

--- a/apps/keycloak/templates/servicemonitor.yaml
+++ b/apps/keycloak/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
+{{- $values := . }}
 {{- range $key, $serviceMonitor := dict "metrics" .Values.serviceMonitor "extra" .Values.extraServiceMonitor }}
-{{- $release := .Release }}
 {{- with $serviceMonitor }}
 {{- if .enabled }}
 ---
@@ -25,7 +25,7 @@ spec:
   {{- toYaml .namespaceSelector | nindent 4 }}
   {{- else }}
   namespaceSelector:
-    {{ $release.namespace }}
+    {{ $values.namespace }}
   {{- end }}
   selector:
     matchLabels:

--- a/apps/keycloak/templates/servicemonitor.yaml
+++ b/apps/keycloak/templates/servicemonitor.yaml
@@ -25,7 +25,8 @@ spec:
   {{- toYaml .namespaceSelector | nindent 4 }}
   {{- else }}
   namespaceSelector:
-    {{ $values.namespace }}
+    matchNames:
+      - {{ $values.namespace }}
   {{- end }}
   selector:
     matchLabels:

--- a/apps/keycloak/templates/servicemonitor.yaml
+++ b/apps/keycloak/templates/servicemonitor.yaml
@@ -1,4 +1,5 @@
 {{- range $key, $serviceMonitor := dict "metrics" .Values.serviceMonitor "extra" .Values.extraServiceMonitor }}
+{{- $release := .Release }}
 {{- with $serviceMonitor }}
 {{- if .enabled }}
 ---
@@ -6,10 +7,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "keycloak.fullname" $ }}-{{ $key }}
-  namespace: {{ .Values.namespace }}
-  {{- with .namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ $release.namespace }}
   {{- with .annotations }}
   annotations:
     {{- range $key, $value := . }}

--- a/apps/keycloak/templates/servicemonitor.yaml
+++ b/apps/keycloak/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "keycloak.fullname" $ }}-{{ $key }}
-  namespace: {{ $release.namespace }}
+  namespace: {{ .namespace }}
   {{- with .annotations }}
   annotations:
     {{- range $key, $value := . }}
@@ -20,9 +20,12 @@ metadata:
   {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .namespaceSelector }}
+  {{- if .namespaceSelector }}
   namespaceSelector:
-  {{- toYaml . | nindent 4 }}
+  {{- toYaml .namespaceSelector | nindent 4 }}
+  {{- else }}
+  namespaceSelector:
+    - {{ $release.namespace }}
   {{- end }}
   selector:
     matchLabels:

--- a/apps/keycloak/templates/servicemonitor.yaml
+++ b/apps/keycloak/templates/servicemonitor.yaml
@@ -25,7 +25,7 @@ spec:
   {{- toYaml .namespaceSelector | nindent 4 }}
   {{- else }}
   namespaceSelector:
-    - {{ $release.namespace }}
+    {{ $release.namespace }}
   {{- end }}
   selector:
     matchLabels:

--- a/apps/keycloak/templates/servicemonitor.yaml
+++ b/apps/keycloak/templates/servicemonitor.yaml
@@ -20,13 +20,9 @@ metadata:
   {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .namespaceSelector }}
+  {{- with .namespaceSelector }}
   namespaceSelector:
   {{- toYaml .namespaceSelector | nindent 4 }}
-  {{- else }}
-  namespaceSelector:
-    matchNames:
-      - {{ $values.namespace }}
   {{- end }}
   selector:
     matchLabels:

--- a/apps/keycloak/templates/servicemonitor.yaml
+++ b/apps/keycloak/templates/servicemonitor.yaml
@@ -22,12 +22,12 @@ metadata:
 spec:
   {{- with .namespaceSelector }}
   namespaceSelector:
-  {{- toYaml .namespaceSelector | nindent 4 }}
+  {{- tpl . $ | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "keycloak.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/component: http
+      app.kubernetes.io/component: metrics
   endpoints:
     - port: {{ .port }}
       path: {{ .path }}

--- a/apps/keycloak/templates/statefulset.yaml
+++ b/apps/keycloak/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
               value: "true"
             {{- with .port }}
             - name: KC_HTTP_MANAGEMENT_PORT
-              value: {{ . | default "9000" }}
+              value: {{ . | default "9000" | quote }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/apps/keycloak/templates/statefulset.yaml
+++ b/apps/keycloak/templates/statefulset.yaml
@@ -77,8 +77,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
           command:
             {{- toYaml .Values.command | nindent 12 }}
+          {{- end }}
           args:
             {{- toYaml .Values.args | nindent 12 }}
           {{- with .Values.lifecycleHooks }}

--- a/apps/keycloak/templates/statefulset.yaml
+++ b/apps/keycloak/templates/statefulset.yaml
@@ -117,6 +117,9 @@ spec:
             - name: https
               containerPort: 8443
               protocol: TCP
+            - name: http-internal
+              containerPort: 9000
+              protocol: TCP
             {{- with .Values.extraPorts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/apps/keycloak/templates/statefulset.yaml
+++ b/apps/keycloak/templates/statefulset.yaml
@@ -105,6 +105,18 @@ spec:
                   name: {{ include "keycloak.postgresql.fullname" . }}
                   key: postgresql-password
             {{- end }}
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            {{- with .Values.metrics }}
+            {{- if .enabled }}
+            - name: KC_METRICS_ENABLED
+              value: "true"
+            {{- with .port }}
+            - name: KC_HTTP_MANAGEMENT_PORT
+              value: {{ . | default "9000" }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- tpl . $ | nindent 12 }}
             {{- end }}
@@ -119,9 +131,13 @@ spec:
             - name: https
               containerPort: 8443
               protocol: TCP
+            {{- with .Values.metrics }}
+            {{- if .enabled }}
             - name: http-internal
-              containerPort: 9000
+              containerPort: {{ .port | default "9000" }}
               protocol: TCP
+            {{- end }}
+            {{- end }}
             {{- with .Values.extraPorts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -13,7 +13,7 @@ image:
   # The Keycloak image repository
   repository: registry1.dso.mil/ironbank/opensource/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "21.1.2"
+  tag: "25.0.2"
   # The Keycloak image pull policy
   pullPolicy: IfNotPresent
 
@@ -67,10 +67,14 @@ rbac:
 # SecurityContext for the entire Pod. Every container running in the Pod will inherit this SecurityContext. This might be relevant when other components of the environment inject additional containers into running Pods (service meshes are the most prominent example for this)
 podSecurityContext:
   fsGroup: 1000
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
 
 # SecurityContext for the Keycloak container
 securityContext:
   runAsUser: 1000
+  runAsGroup: 1000
   runAsNonRoot: true
   capabilities:
     drop:
@@ -105,17 +109,14 @@ terminationGracePeriodSeconds: 60
 clusterDomain: cluster.local
 
 ## Overrides the default entrypoint of the Keycloak container
-command:
-  - "/opt/keycloak/bin/kc.sh"
+command: []
 
 ## Overrides the default args for the Keycloak container
 args:
   - "start"
-  #- "--proxy edge"
 
 # Additional environment variables for Keycloak
 # https://www.keycloak.org/server/all-config
-#extraEnv: ""
 extraEnv: |
   - name: KC_PROXY
     value: "edge"
@@ -125,8 +126,13 @@ extraEnv: |
     value: kubernetes
   - name: KC_CACHE
     value: ispn
+  - name: KC_LOG_LEVEL
+    value: "org.keycloak.events:DEBUG"
   - name: KC_METRICS_ENABLED
     value: true
+  - name: KC_HEALTH_ENABLED
+    value: true
+
 #  - name: KC_HTTP_RELATIVE_PATH
 #    value: /auth
 #   - name: KC_HTTPS_CERTIFICATE_FILE
@@ -205,7 +211,7 @@ podAnnotations: {}
 #### Updated for Big Bang ####
 livenessProbe: |
   httpGet:
-    path: /
+    path: /health
     port: http
     scheme: HTTP
   failureThreshold: 15
@@ -217,7 +223,7 @@ livenessProbe: |
 #### Updated for Big Bang ####
 readinessProbe: |
   httpGet:
-    path: /realms/master
+    path: /health
     port: http
     scheme: HTTP
   failureThreshold: 15
@@ -228,7 +234,7 @@ readinessProbe: |
 #### Updated for Big Bang ####
 startupProbe: |
   httpGet:
-    path: /realms/master
+    path: /health
     port: http
   initialDelaySeconds: 90
   timeoutSeconds: 2
@@ -528,7 +534,7 @@ serviceMonitor:
   # The path at which metrics are served
   path: /metrics
   # The Service port at which metrics are served
-  port: http
+  port: http-internal
   # added by Big Bang to support Istio mTLS
   scheme: ""
   tlsConfig: {}

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -125,6 +125,8 @@ extraEnv: |
     value: kubernetes
   - name: KC_CACHE
     value: ispn
+  - name: KC_METRICS_ENABLED
+    value: true
 #  - name: KC_HTTP_RELATIVE_PATH
 #    value: /auth
 #   - name: KC_HTTPS_CERTIFICATE_FILE

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -508,9 +508,9 @@ postgresql:
 
 serviceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created
-  enabled: false
+  enabled: true
   # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
-  namespace: opal
+  namespace: {}
   # Optionally sets a namespace for the ServiceMonitor
   namespaceSelector: {}
   # Annotations for the ServiceMonitor
@@ -533,7 +533,7 @@ extraServiceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created
   enabled: false
   # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
-  namespace: opal
+  namespace: {}
   # Optionally sets a namespace for the ServiceMonitor
   namespaceSelector: {}
   # Annotations for the ServiceMonitor

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -66,15 +66,15 @@ rbac:
 
 # SecurityContext for the entire Pod. Every container running in the Pod will inherit this SecurityContext. This might be relevant when other components of the environment inject additional containers into running Pods (service meshes are the most prominent example for this)
 podSecurityContext:
-  fsGroup: 1000
-  runAsUser: 1000
-  runAsGroup: 1000
+  fsGroup: 2000
+  runAsUser: 2000
+  runAsGroup: 2000
   runAsNonRoot: true
 
 # SecurityContext for the Keycloak container
 securityContext:
-  runAsUser: 1000
-  runAsGroup: 1000
+  runAsUser: 2000
+  runAsGroup: 2000
   runAsNonRoot: true
   capabilities:
     drop:
@@ -441,8 +441,8 @@ pgchecker:
   # SecurityContext for the pgchecker container
   securityContext:
     allowPrivilegeEscalation: false
-    runAsUser: 1000
-    runAsGroup: 1000
+    runAsUser: 2000
+    runAsGroup: 2000
     runAsNonRoot: true
     capabilities:
       drop:

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -510,7 +510,7 @@ serviceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created
   enabled: true
   # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
-  namespace: {}
+  namespace: monitoring
   # Optionally sets a namespace for the ServiceMonitor
   namespaceSelector: {}
   # Annotations for the ServiceMonitor

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -512,7 +512,9 @@ serviceMonitor:
   # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
   namespace: monitoring
   # Optionally sets a namespace for the ServiceMonitor
-  namespaceSelector: {}
+  namespaceSelector:
+    matchNames:
+      - *ns
   # Annotations for the ServiceMonitor
   annotations: {}
   # Additional labels for the ServiceMonitor

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -129,10 +129,9 @@ extraEnv: |
   - name: KC_LOG_LEVEL
     value: "org.keycloak.events:DEBUG"
   - name: KC_METRICS_ENABLED
-    value: true
+    value: "true"
   - name: KC_HEALTH_ENABLED
-    value: true
-
+    value: "true"
 #  - name: KC_HTTP_RELATIVE_PATH
 #    value: /auth
 #   - name: KC_HTTPS_CERTIFICATE_FILE

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -317,7 +317,7 @@ service:
   extraPorts:
     - name: http-internal
       port: 9000
-      targetPort: {{ tpl .Values.http.internalPort }}
+      targetPort: http-internal
       protocol: TCP
   # When using Service type LoadBalancer, you can restrict source ranges allowed
   # to connect to the LoadBalancer, e.g. will result in Security Groups

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -210,7 +210,7 @@ podAnnotations: {}
 #### Updated for Big Bang ####
 livenessProbe: |
   httpGet:
-    path: /health
+    path: /health/live
     port: http-internal
     scheme: HTTP
   failureThreshold: 15
@@ -222,7 +222,7 @@ livenessProbe: |
 #### Updated for Big Bang ####
 readinessProbe: |
   httpGet:
-    path: /health
+    path: /health/ready
     port: http-internal
     scheme: HTTP
   failureThreshold: 15
@@ -314,7 +314,11 @@ service:
   # The HTTPS Service node port if type is NodePort
   httpsNodePort: null
   # Additional Service ports, e.g. for custom admin console
-  extraPorts: []
+  extraPorts:
+    - name: http-internal
+      port: 9000
+      targetPort: {{ tpl .Values.http.internalPort }}
+      protocol: TCP
   # When using Service type LoadBalancer, you can restrict source ranges allowed
   # to connect to the LoadBalancer, e.g. will result in Security Groups
   # (or equivalent) with inbound source ranges allowed to connect

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -520,7 +520,7 @@ serviceMonitor:
   namespace: monitoring
   # Optionally sets a namespace for the ServiceMonitor
   namespaceSelector:
-    matchNames:
+    matchName:
       - *ns
   # Annotations for the ServiceMonitor
   annotations: {}

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -128,10 +128,6 @@ extraEnv: |
     value: ispn
   - name: KC_LOG_LEVEL
     value: "org.keycloak.events:DEBUG"
-  - name: KC_METRICS_ENABLED
-    value: "true"
-  - name: KC_HEALTH_ENABLED
-    value: "true"
 #  - name: KC_HTTP_RELATIVE_PATH
 #    value: /auth
 #   - name: KC_HTTPS_CERTIFICATE_FILE
@@ -207,7 +203,6 @@ podLabels: {}
 podAnnotations: {}
 
 # Liveness probe configuration
-#### Updated for Big Bang ####
 livenessProbe: |
   httpGet:
     path: /health/live
@@ -219,7 +214,6 @@ livenessProbe: |
   initialDelaySeconds: 300
 
 # Readiness probe configuration
-#### Updated for Big Bang ####
 readinessProbe: |
   httpGet:
     path: /health/ready
@@ -230,7 +224,6 @@ readinessProbe: |
   initialDelaySeconds: 30
 
 # Startup probe configuration
-#### Updated for Big Bang ####
 startupProbe: |
   httpGet:
     path: /health
@@ -248,6 +241,7 @@ resources:
   limits:
     cpu: "1"
     memory: "1Gi"
+
 
 #### starupScripts removed. Not relevant for Quarkus distribution ####
 
@@ -512,6 +506,10 @@ postgresql:
     limits:
       cpu: "250m"
       memory: "256Mi"
+
+metrics:
+  enabled: false
+  port: "9000"
 
 serviceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -513,7 +513,7 @@ metrics:
 
 serviceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created
-  enabled: true
+  enabled: false
   # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
   namespace: monitoring
   # Optionally sets a namespace for the ServiceMonitor

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -519,9 +519,7 @@ serviceMonitor:
   # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
   namespace: monitoring
   # Optionally sets a namespace for the ServiceMonitor
-  namespaceSelector:
-    matchName:
-      - *ns
+  namespaceSelector: {}
   # Annotations for the ServiceMonitor
   annotations: {}
   # Additional labels for the ServiceMonitor

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -532,7 +532,7 @@ serviceMonitor:
   # Timeout for scraping
   scrapeTimeout: 10s
   # The path at which metrics are served
-  path: /realms/master/metrics
+  path: /metrics
   # The Service port at which metrics are served
   port: http-internal
   # added by Big Bang to support Istio mTLS

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -532,7 +532,7 @@ serviceMonitor:
   # Timeout for scraping
   scrapeTimeout: 10s
   # The path at which metrics are served
-  path: /metrics
+  path: /realms/master/metrics
   # The Service port at which metrics are served
   port: http-internal
   # added by Big Bang to support Istio mTLS

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -314,11 +314,7 @@ service:
   # The HTTPS Service node port if type is NodePort
   httpsNodePort: null
   # Additional Service ports, e.g. for custom admin console
-  extraPorts:
-    - name: http-internal
-      port: 9000
-      targetPort: http-internal
-      protocol: TCP
+  extraPorts: []
   # When using Service type LoadBalancer, you can restrict source ranges allowed
   # to connect to the LoadBalancer, e.g. will result in Security Groups
   # (or equivalent) with inbound source ranges allowed to connect
@@ -523,7 +519,10 @@ serviceMonitor:
   # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
   namespace: monitoring
   # Optionally sets a namespace for the ServiceMonitor
-  namespaceSelector: {}
+  namespaceSelector: |
+    matchNames:
+      - {{ tpl .Values.namespace $ }}
+
   # Annotations for the ServiceMonitor
   annotations: {}
   # Additional labels for the ServiceMonitor

--- a/apps/keycloak/values.yaml
+++ b/apps/keycloak/values.yaml
@@ -211,7 +211,7 @@ podAnnotations: {}
 livenessProbe: |
   httpGet:
     path: /health
-    port: http
+    port: http-internal
     scheme: HTTP
   failureThreshold: 15
   timeoutSeconds: 2
@@ -223,7 +223,7 @@ livenessProbe: |
 readinessProbe: |
   httpGet:
     path: /health
-    port: http
+    port: http-internal
     scheme: HTTP
   failureThreshold: 15
   timeoutSeconds: 2
@@ -234,7 +234,7 @@ readinessProbe: |
 startupProbe: |
   httpGet:
     path: /health
-    port: http
+    port: http-internal
   initialDelaySeconds: 90
   timeoutSeconds: 2
   failureThreshold: 60

--- a/opal-setup/values.yaml
+++ b/opal-setup/values.yaml
@@ -1,6 +1,6 @@
 # leave these empty to disable them in the rendered app yamls
-argoProject: &argoProj "test"
-appPrefix: &appPrefix "test"
+argoProject: &argoProj ""
+appPrefix: &appPrefix ""
 
 namespaces:
   - &minioNS minio-tenant

--- a/opal/aks-values.yaml
+++ b/opal/aks-values.yaml
@@ -59,6 +59,8 @@ keycloak:
     keycloakSetup:
       enabled: true
       existingSecret: *oauthSecret
+    metrics:
+      enabled: true
   postgres:
     nameOverride: *keycloakPostgresName
     namespace: *opalNS

--- a/opal/aks-values.yaml
+++ b/opal/aks-values.yaml
@@ -61,6 +61,8 @@ keycloak:
       existingSecret: *oauthSecret
     metrics:
       enabled: true
+    serviceMonitor:
+      enabled: true
   postgres:
     nameOverride: *keycloakPostgresName
     namespace: *opalNS

--- a/opal/prod-values.yaml
+++ b/opal/prod-values.yaml
@@ -59,6 +59,8 @@ keycloak:
     keycloakSetup:
       enabled: true
       existingSecret: *oauthSecret
+    metrics:
+      enabled: true
   postgres:
     nameOverride: *keycloakPostgresName
     namespace: *opalNS

--- a/opal/prod-values.yaml
+++ b/opal/prod-values.yaml
@@ -61,6 +61,8 @@ keycloak:
       existingSecret: *oauthSecret
     metrics:
       enabled: true
+    serviceMonitor:
+      enabled: true
   postgres:
     nameOverride: *keycloakPostgresName
     namespace: *opalNS

--- a/opal/test-values.yaml
+++ b/opal/test-values.yaml
@@ -63,6 +63,8 @@ keycloak:
       existingSecret: *oauthSecret
     metrics:
       enabled: true
+    serviceMonitor:
+      enabled: true
   postgres:
     nameOverride: *keycloakPostgresName
     namespace: *opalNS

--- a/opal/test-values.yaml
+++ b/opal/test-values.yaml
@@ -61,6 +61,8 @@ keycloak:
     keycloakSetup:
       enabled: true
       existingSecret: *oauthSecret
+    metrics:
+      enabled: true
   postgres:
     nameOverride: *keycloakPostgresName
     namespace: *opalNS

--- a/opal/values.yaml
+++ b/opal/values.yaml
@@ -59,6 +59,8 @@ keycloak:
     keycloakSetup:
       enabled: true
       existingSecret: *oauthSecret
+    metrics:
+      enabled: true
   postgres:
     nameOverride: *keycloakPostgresName
     namespace: *opalNS

--- a/opal/values.yaml
+++ b/opal/values.yaml
@@ -61,6 +61,8 @@ keycloak:
       existingSecret: *oauthSecret
     metrics:
       enabled: true
+    serviceMonitor:
+      enabled: true
   postgres:
     nameOverride: *keycloakPostgresName
     namespace: *opalNS


### PR DESCRIPTION
Change `targetRevision` in `opal-setup/values.yaml` to `OPAL-652`

Metrics can be viewed in prometheus by entering `{container='keycloak'}` in the search bar on the Graph tab.
In grafana, visualizations can be viewed by going to metrics -> new -> add label -> container -> keycloak