### PR TITLE
Opal 653

### DIFF
--- a/apps/traefik/templates/cluster-role.yaml
+++ b/apps/traefik/templates/cluster-role.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/apps/traefik/templates/clusterrolebinding.yaml
+++ b/apps/traefik/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.enabled }}
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/apps/traefik/templates/deployment.yaml
+++ b/apps/traefik/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
               containerPort: 8000
             - name: websecure
               containerPort: 8443
+            - name: metrics
+              containerPort: 8082
           volumeMounts:
             - name: traefik-cfg
               mountPath: /etc/traefik/traefik.toml

--- a/apps/traefik/templates/deployment.yaml
+++ b/apps/traefik/templates/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,14 +26,18 @@ spec:
       serviceAccountName: {{ include "traefik.fullname" .}}-account
       containers:
         - name: {{ include "traefik.fullname" . }}
-          image: registry1.dso.mil/ironbank/opensource/traefik/traefik:v2.9.1
+          image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           ports:
             - name: web
               containerPort: 8000
             - name: websecure
               containerPort: 8443
+            {{- with .Values.serviceMonitor }}
+            {{- if .enabled }}
             - name: metrics
-              containerPort: 8082
+              containerPort: {{ .port }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: traefik-cfg
               mountPath: /etc/traefik/traefik.toml

--- a/apps/traefik/templates/deployment.yaml
+++ b/apps/traefik/templates/deployment.yaml
@@ -32,11 +32,9 @@ spec:
               containerPort: 8000
             - name: websecure
               containerPort: 8443
-            {{- with .Values.serviceMonitor }}
-            {{- if .enabled }}
+            {{- if .Values.metrics.enabled }}
             - name: metrics
-              containerPort: {{ .port }}
-            {{- end }}
+              containerPort: {{ .Values.metrics.port }}
             {{- end }}
           volumeMounts:
             - name: traefik-cfg

--- a/apps/traefik/templates/ingress.yaml
+++ b/apps/traefik/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- $ingress := .Values.ingress -}}
 {{ if .Values.ingress.enabled }}
+---
 {{- $apiV1 := false -}}
 {{- $apiVersion := "extensions/v1beta1" -}}
 {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= v1.19.0-0" .Capabilities.KubeVersion.Version) -}}

--- a/apps/traefik/templates/service-metrics.yaml
+++ b/apps/traefik/templates/service-metrics.yaml
@@ -1,17 +1,14 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if .Values.metrics.enabled }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Values.namespace}}
+  namespace: {{ .Values.namespace }}
   name: {{ include "traefik.fullname" . }}-metrics
   annotations:
     {{- .Values.service.annotations | toYaml | nindent 4 }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
-    {{- range $key, $value := .Values.service.labels }}
-    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
-    {{- end }}
     app.kubernetes.io/component: metrics
 spec:
   type: ClusterIP
@@ -19,7 +16,7 @@ spec:
     app: {{ include "traefik.fullname" . }}
   ports:
     - protocol: TCP
-      port: {{ .Values.serviceMonitor.port }}
+      port: {{ .Values.metrics.port }}
       name: metrics
       targetPort: metrics
 {{- end }}

--- a/apps/traefik/templates/service-metrics.yaml
+++ b/apps/traefik/templates/service-metrics.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- range $key, $value := .Values.service.labels }}
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
-    app.kubernetes.io/component:
+    app.kubernetes.io/component: metrics
 spec:
   type: ClusterIP
   selector:

--- a/apps/traefik/templates/service-metrics.yaml
+++ b/apps/traefik/templates/service-metrics.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,6 +19,7 @@ spec:
     app: {{ include "traefik.fullname" . }}
   ports:
     - protocol: TCP
-      port: 8082
+      port: {{ .Values.serviceMonitor.port }}
       name: metrics
       targetPort: metrics
+{{- end }}

--- a/apps/traefik/templates/service-metrics.yaml
+++ b/apps/traefik/templates/service-metrics.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: {{ .Values.namespace}}
-  name: {{ include "traefik.fullname" . }}-service
+  name: {{ include "traefik.fullname" . }}-metrics
   annotations:
     {{- .Values.service.annotations | toYaml | nindent 4 }}
   labels:
@@ -10,20 +10,13 @@ metadata:
     {{- range $key, $value := .Values.service.labels }}
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
-    app.kubernetes.io/component: http
+    app.kubernetes.io/component:
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: {{ include "traefik.fullname" . }}
   ports:
     - protocol: TCP
-      port: 80
-      name: web
-      targetPort: web
-    - protocol: TCP
-      port: 443
-      name: websecure
-      targetPort: websecure
-  {{- if .Values.service.loadBalancerIP }}
-  clusterIP: {{ .Values.service.loadBalancerIP }}
-  {{- end }}
+      port: 8082
+      name: metrics
+      targetPort: metrics

--- a/apps/traefik/templates/service.yaml
+++ b/apps/traefik/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/traefik/templates/serviceaccount.yaml
+++ b/apps/traefik/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.serviceAccount.create }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/apps/traefik/templates/servicemonitor.yaml
+++ b/apps/traefik/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- $values := . }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "traefik.fullname" $ }}
+  namespace: {{ .namespace }}
+  {{- with .annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  labels:
+  {{- include "traefik.labels" $ | nindent 4 }}
+  {{- range $key, $value := .labels }}
+  {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- tpl . $ | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "traefik.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: {{ .port }}
+      path: {{ .path }}
+      interval: {{ .interval }}
+      scrapeTimeout: {{ .scrapeTimeout }}
+      {{- if .scheme }}
+      scheme: {{ .scheme }}
+      {{- end }}
+      {{- if .tlsConfig }}
+      tlsConfig:
+        {{- toYaml .tlsConfig | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/apps/traefik/templates/servicemonitor.yaml
+++ b/apps/traefik/templates/servicemonitor.yaml
@@ -26,7 +26,7 @@ spec:
   selector:
     matchLabels:
       {{- include "traefik.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/component: metrics
+      app.kubernetes.io/component: http
   endpoints:
     - port: {{ .port }}
       path: {{ .path }}

--- a/apps/traefik/templates/servicemonitor.yaml
+++ b/apps/traefik/templates/servicemonitor.yaml
@@ -26,7 +26,7 @@ spec:
   selector:
     matchLabels:
       {{- include "traefik.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/component: http
+      app.kubernetes.io/component: metrics
   endpoints:
     - port: {{ .port }}
       path: {{ .path }}

--- a/apps/traefik/templates/traefik-config-configmap.yaml
+++ b/apps/traefik/templates/traefik-config-configmap.yaml
@@ -26,9 +26,20 @@ data:
     [entryPoints.websecure]
     address = ":8443"
 
+    [entryPoints.metrics]
+    address: ":8082"
+
     [api]
     insecure = true
     dashboard = false
+
+    [metrics.prometheus]
+    entryPoint = "metrics"
+    addServicesLabels = true
+    addRoutersLabels = true
+    addEntryPointsLabels = true
+    buckets = [0.1,0.3,1.2,5.0]
+
 
 
     [log]

--- a/apps/traefik/templates/traefik-config-configmap.yaml
+++ b/apps/traefik/templates/traefik-config-configmap.yaml
@@ -27,10 +27,9 @@ data:
     [entryPoints.websecure]
     address = ":8443"
 
-    {{- with .Values.serviceMonitor }}
-    {{- if .enabled }}
+    {{- if .Values.metrics.enabled }}
     [entryPoints.metrics]
-    address = ":{{ .port }}"
+    address = ":{{ .Values.metrics.port }}"
 
     [metrics.prometheus]
     entryPoint = "metrics"
@@ -38,7 +37,6 @@ data:
     addRoutersLabels = true
     addEntryPointsLabels = true
     buckets = [0.1,0.3,1.2,5.0]
-    {{- end }}
     {{- end }}
 
     [api]

--- a/apps/traefik/templates/traefik-config-configmap.yaml
+++ b/apps/traefik/templates/traefik-config-configmap.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,12 +27,10 @@ data:
     [entryPoints.websecure]
     address = ":8443"
 
+    {{- with .Values.serviceMonitor }}
+    {{- if .enabled }}
     [entryPoints.metrics]
-    address = ":8082"
-
-    [api]
-    insecure = true
-    dashboard = false
+    address = ":{{ .port }}"
 
     [metrics.prometheus]
     entryPoint = "metrics"
@@ -39,7 +38,12 @@ data:
     addRoutersLabels = true
     addEntryPointsLabels = true
     buckets = [0.1,0.3,1.2,5.0]
+    {{- end }}
+    {{- end }}
 
+    [api]
+    insecure = true
+    dashboard = false
 
 
     [log]

--- a/apps/traefik/templates/traefik-config-configmap.yaml
+++ b/apps/traefik/templates/traefik-config-configmap.yaml
@@ -27,7 +27,7 @@ data:
     address = ":8443"
 
     [entryPoints.metrics]
-    address: ":8082"
+    address = ":8082"
 
     [api]
     insecure = true

--- a/apps/traefik/templates/traefik-config-dynamic-configmap.yaml
+++ b/apps/traefik/templates/traefik-config-dynamic-configmap.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/apps/traefik/values.yaml
+++ b/apps/traefik/values.yaml
@@ -115,6 +115,10 @@ service:
   # Session affinity config
   sessionAffinityConfig: {}
 
+metrics:
+  enabled: false
+  port: 8082
+
 ingress:
   # If `true`, an Ingress is created
   enabled: false
@@ -158,7 +162,7 @@ networkPolicy:
 
 serviceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created
-  enabled: false
+  enabled: true
   # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
   namespace: "monitoring"
   # Optionally sets a namespace for the ServiceMonitor

--- a/apps/traefik/values.yaml
+++ b/apps/traefik/values.yaml
@@ -116,7 +116,7 @@ service:
 
 ingress:
   # If `true`, an Ingress is created
-  enabled: true
+  enabled: false
   # The Service port targeted by the Ingress
   servicePort: http
   # Ingress annotations
@@ -160,9 +160,11 @@ serviceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created
   enabled: false
   # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
-  namespace: ""
+  namespace: "monitoring"
   # Optionally sets a namespace for the ServiceMonitor
-  namespaceSelector: {}
+  namespaceSelector: |
+    matchNames:
+      - {{ .Values.namespace }}
   # Annotations for the ServiceMonitor
   annotations: {}
   # Additional labels for the ServiceMonitor
@@ -174,60 +176,10 @@ serviceMonitor:
   # The path at which metrics are served
   path: /metrics
   # The Service port at which metrics are served
-  port: http
+  port: metrics
   # added by Big Bang to support Istio mTLS
   scheme: ""
   tlsConfig: {}
-
-extraServiceMonitor:
-  # If `true`, a ServiceMonitor resource for the prometheus-operator is created
-  enabled: false
-  # Optionally sets a target namespace in which to deploy the ServiceMonitor resource
-  namespace: ""
-  # Optionally sets a namespace for the ServiceMonitor
-  namespaceSelector: {}
-  # Annotations for the ServiceMonitor
-  annotations: {}
-  # Additional labels for the ServiceMonitor
-  labels: {}
-  # Interval at which Prometheus scrapes metrics
-  interval: 10s
-  # Timeout for scraping
-  scrapeTimeout: 10s
-  # The path at which metrics are served
-  path: /auth/realms/master/metrics
-  # The Service port at which metrics are served
-  port: http
-
-prometheusRule:
-  # If `true`, a PrometheusRule resource for the prometheus-operator is created
-  enabled: false
-  # Annotations for the PrometheusRule
-  annotations: {}
-  # Additional labels for the PrometheusRule
-  labels: {}
-  # List of rules for Prometheus
-  rules: []
-  # - alert: traefik-IngressHigh5xxRate
-  #   annotations:
-  #     message: The percentage of 5xx errors for traefik over the last 5 minutes is over 1%.
-  #   expr: |
-  #     (
-  #       sum(
-  #         rate(
-  #           nginx_ingress_controller_response_duration_seconds_count{exported_namespace="mynamespace",ingress="mynamespace-traefik",status=~"5[0-9]{2}"}[1m]
-  #         )
-  #       )
-  #       /
-  #       sum(
-  #         rate(
-  #           nginx_ingress_controller_response_duration_seconds_count{exported_namespace="mynamespace",ingress="mynamespace-traefik"}[1m]
-  #         )
-  #       )
-  #     ) * 100 > 1
-  #   for: 5m
-  #   labels:
-  #     severity: warning
 
 autoscaling:
   # If `true`, an autoscaling/v2beta2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.18 or above)

--- a/apps/traefik/values.yaml
+++ b/apps/traefik/values.yaml
@@ -11,10 +11,11 @@ namespace: "opal"
 replicas: 1
 
 image:
+  registry: registry1.dso.mil/ironbank/opensource/traefik
   # The Traefik image repository
-  repository: registry1.dso.mil/ironbank/opensource/traefik/traefik
+  repository: traefik
   # Overrides the Traefik image tag whose default is the chart appVersion
-  tag: "v2.10.4"
+  tag: "v3.0.4"
   # The Traefik image pull policy
   pullPolicy: IfNotPresent
 
@@ -154,7 +155,6 @@ networkPolicy:
   # Define all other external allowed source
   # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicypeer-v1-networking-k8s-io
   extraFrom: []
-
 
 serviceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created

--- a/opal/aks-values.yaml
+++ b/opal/aks-values.yaml
@@ -107,6 +107,10 @@ traefik:
       tag: "v3.0.4"
     service:
       loadBalancerIP: ""
+    serviceMonitor:
+      enabled: true
+    metrics:
+      enabled: true
     tls:
       nameOverride: *tlsSecret
     ingress:

--- a/opal/aks-values.yaml
+++ b/opal/aks-values.yaml
@@ -18,6 +18,8 @@ namespaces:
   - &opalNS opal
   - &minioNS minio-tenant
 
+tokenEnv: &tokenEnv "token-env"
+
 source:
   url: ""
   targetRevision: ""
@@ -102,7 +104,7 @@ traefik:
   appValues:
     namespace: *opalNS
     image:
-      tag: "v2.10.4"
+      tag: "v3.0.4"
     service:
       loadBalancerIP: ""
     tls:

--- a/opal/prod-values.yaml
+++ b/opal/prod-values.yaml
@@ -107,6 +107,10 @@ traefik:
       tag: "v3.0.4"
     service:
       loadBalancerIP: ""
+    serviceMonitor:
+      enabled: true
+    metrics:
+      enabled: true
     tls:
       nameOverride: *tlsSecret
     ingress:

--- a/opal/prod-values.yaml
+++ b/opal/prod-values.yaml
@@ -18,6 +18,8 @@ namespaces:
   - &opalNS opal
   - &minioNS minio-tenant
 
+tokenEnv: &tokenEnv "token-env"
+
 source:
   url: ""
   targetRevision: ""
@@ -102,7 +104,7 @@ traefik:
   appValues:
     namespace: *opalNS
     image:
-      tag: "v2.10.4"
+      tag: "v3.0.4"
     service:
       loadBalancerIP: ""
     tls:

--- a/opal/test-values.yaml
+++ b/opal/test-values.yaml
@@ -104,7 +104,7 @@ traefik:
   appValues:
     namespace: *opalNS
     image:
-      tag: "v2.10.4"
+      tag: "v3.0.4"
     service:
       loadBalancerIP: "10.96.30.9"
     serviceMonitor:

--- a/opal/test-values.yaml
+++ b/opal/test-values.yaml
@@ -107,6 +107,8 @@ traefik:
       tag: "v2.10.4"
     service:
       loadBalancerIP: "10.96.30.9"
+    serviceMonitor:
+      enabled: true
     tls:
       nameOverride: *tlsSecret
     ingress:

--- a/opal/test-values.yaml
+++ b/opal/test-values.yaml
@@ -109,6 +109,8 @@ traefik:
       loadBalancerIP: "10.96.30.9"
     serviceMonitor:
       enabled: true
+    metrics:
+      enabled: true
     tls:
       nameOverride: *tlsSecret
     ingress:

--- a/opal/values.yaml
+++ b/opal/values.yaml
@@ -107,6 +107,10 @@ traefik:
       tag: "v3.0.4"
     service:
       loadBalancerIP: ""
+    serviceMonitor:
+      enabled: true
+    metrics:
+      enabled: true
     tls:
       nameOverride: *tlsSecret
     ingress:

--- a/opal/values.yaml
+++ b/opal/values.yaml
@@ -18,6 +18,8 @@ namespaces:
   - &opalNS opal
   - &minioNS minio-tenant
 
+tokenEnv: &tokenEnv "token-env"
+
 source:
   url: ""
   targetRevision: ""
@@ -102,7 +104,7 @@ traefik:
   appValues:
     namespace: *opalNS
     image:
-      tag: "v2.10.4"
+      tag: "v3.0.4"
     service:
       loadBalancerIP: ""
     tls:


### PR DESCRIPTION
To test:

Ensure prometheus is installed to the "monitoring" namespace

Change `tagetRevision` in `opal-setup/values.yaml` to `OPAL-653`

Metrics should be visible in prometheus/grafana with the prefix `traefik_`