### PR TITLE
Dask image test

### DIFF
--- a/apps/dask-gateway/values.schema.yaml
+++ b/apps/dask-gateway/values.schema.yaml
@@ -89,7 +89,7 @@ properties:
               docs](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
               for more info.
       imagePullSecrets: &imagePullSecrets-spec
-        type: object
+        type: array
         description: |
           A list of references to existing k8s Secrets with credentials to pull
           the image.

--- a/apps/dask-gateway/values.schema.yaml
+++ b/apps/dask-gateway/values.schema.yaml
@@ -89,7 +89,7 @@ properties:
               docs](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
               for more info.
       imagePullSecrets: &imagePullSecrets-spec
-        type: array
+        type: object
         description: |
           A list of references to existing k8s Secrets with credentials to pull
           the image.

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -45,8 +45,7 @@ gateway:
 
   # Image pull secrets for gateway-server pod
   imagePullSecrets: 
-    name: regcred
-    existingSecret: ""
+    - regcred
 
   # Configuration for the gateway-server service
   service:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -127,7 +127,7 @@ gateway:
   backend:
     # The image to use for both schedulers and workers.
     image:
-      name: opensource/309theddge/dask-gateway-controller 
+      name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller 
       tag: "dask_gateway_controller_v1"
       pullPolicy: IfNotPresent
 

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -33,7 +33,7 @@ gateway:
   # The image to use for the dask-gateway-server pod (api pod)
   image:
     name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
-    tag: "dask_gateway_api_v1"
+    tag: dask_gateway_api_v1
     pullPolicy:
 
   # Add additional environment variables to the gateway pod

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -31,14 +31,14 @@ gateway:
   loglevel: INFO
 
   # The image to use for the dask-gateway-server pod (api pod)
-  #image:
-    #name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
-    #tag: dask_gateway_api_v1
-    #pullPolicy: IfNotPresent
   image:
-    name: ghcr.io/dask/dask-gateway-server
-    tag: "2024.1.0"
-    pullPolicy:
+    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
+    tag: dask_gateway_api_v1
+    pullPolicy: IfNotPresent
+  #image:
+   # name: ghcr.io/dask/dask-gateway-server
+    #tag: "2024.1.0"
+    #pullPolicy:
   # Add additional environment variables to the gateway pod
   # e.g.
   # env:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -32,7 +32,7 @@ gateway:
 
   # The image to use for the dask-gateway-server pod (api pod)
   image:
-    name: registry1.dso.mil/ironbank/opensource
+    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
     tag: "dask_gateway_api_v1"
     pullPolicy:
 

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -42,10 +42,10 @@ gateway:
   # - name: MYENV
   #   value: "my value"
   env: []
-  
+
   # Image pull secrets for gateway-server pod
   imagePullSecrets: 
-    name: regcred
+    name: [regcred]
 
   # Configuration for the gateway-server service
   service:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -45,7 +45,8 @@ gateway:
 
   # Image pull secrets for gateway-server pod
   imagePullSecrets: 
-    name: [regcred]
+    name: regcred
+    existingSecret: ""
 
   # Configuration for the gateway-server service
   service:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -32,7 +32,7 @@ gateway:
 
   # The image to use for the dask-gateway-server pod (api pod)
   image:
-    name: registry1.dso.mil/opensource/309th/dask-gateway-api
+    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
     tag: dask_gateway_api_v1
     pullPolicy: IfNotPresent
 

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -32,7 +32,7 @@ gateway:
 
   # The image to use for the dask-gateway-server pod (api pod)
   image:
-    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-controller
+    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
     tag: dask_gateway_controller_v1
     pullPolicy: IfNotPresent
 

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -131,9 +131,13 @@ gateway:
   #    tag: "dask_gateway_controller_v1"
   #    pullPolicy: IfNotPresent
     image:
-      name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-worker
-      tag: "dask-gateway-worker_v1"
+      name: ghcr.io/dask/dask-gateway
+      tag: "2024.1.0"
       pullPolicy:
+    #image:
+      #name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-worker
+      #tag: "dask-gateway-worker_v1"
+      #pullPolicy:
     # Image pull secrets for a dask cluster's scheduler and worker pods
   #  imagePullSecrets: 
   #    - name: regcred

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -32,8 +32,8 @@ gateway:
 
   # The image to use for the dask-gateway-server pod (api pod)
   image:
-    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-    tag: dask_gateway_controller_v1
+    name: registry1.dso.mil/opensource/309th/dask-gateway-api
+    tag: dask_gateway_api_v1
     pullPolicy: IfNotPresent
 
   # Add additional environment variables to the gateway pod

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -231,13 +231,18 @@ controller:
 
   # The image to use for the controller pod.
   #image:
-  #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-  #  tag: "dask_gateway_controller_v1"
-  #  pullPolicy: IfNotPresent
+   # name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
+   # tag: "dask_gateway_controller_v1"
+   # pullPolicy: IfNotPresent
   image:
     name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
     tag: dask_gateway_api_v1
     pullPolicy: IfNotPresent
+
+  #image:
+  #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
+  #  tag: "dask_gateway_controller_v1"
+  #  pullPolicy: IfNotPresent
   imagePullSecrets: 
     - name: regcred
   # Settings for nodeSelector, affinity, and tolerations for the controller pods

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -231,9 +231,9 @@ controller:
 
   # The image to use for the controller pod.
   #image:
-   # name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-   # tag: "dask_gateway_controller_v1"
-   # pullPolicy: IfNotPresent
+  #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
+  #  tag: "dask_gateway_controller_v1"
+  #  pullPolicy: IfNotPresent
   image:
     name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
     tag: dask_gateway_api_v1

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -126,14 +126,17 @@ gateway:
   # created for DaskCluster k8s resources by the controller.
   backend:
     # The image to use for both schedulers and workers.
+  #  image:
+  #    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
+  #    tag: "dask_gateway_controller_v1"
+  #    pullPolicy: IfNotPresent
     image:
-      name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-      tag: "dask_gateway_controller_v1"
-      pullPolicy: IfNotPresent
-
+      name: ghcr.io/dask/dask-gateway-server
+      tag: "2024.1.0"
+      pullPolicy:
     # Image pull secrets for a dask cluster's scheduler and worker pods
-    imagePullSecrets: 
-      - name: regcred
+  #  imagePullSecrets: 
+  #    - name: regcred
 
     # The namespace to launch dask clusters in. If not specified, defaults to
     # the same namespace the gateway is running in.
@@ -227,11 +230,15 @@ controller:
 
   # The image to use for the controller pod.
   image:
-    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-    tag: "dask_gateway_controller_v1"
-    pullPolicy: IfNotPresent
-  imagePullSecrets: 
-    - name: regcred
+    name: ghcr.io/dask/dask-gateway-server
+    tag: "2024.1.0"
+    pullPolicy:
+  #image:
+  #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
+  #  tag: "dask_gateway_controller_v1"
+  #  pullPolicy: IfNotPresent
+  #imagePullSecrets: 
+  #  - name: regcred
   # Settings for nodeSelector, affinity, and tolerations for the controller pods
   nodeSelector: {}
   affinity: {}

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -31,11 +31,14 @@ gateway:
   loglevel: INFO
 
   # The image to use for the dask-gateway-server pod (api pod)
+  #image:
+    #name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
+    #tag: dask_gateway_api_v1
+    #pullPolicy: IfNotPresent
   image:
-    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
-    tag: dask_gateway_api_v1
-    pullPolicy: IfNotPresent
-
+    name: ghcr.io/dask/dask-gateway-server
+    tag: "2024.1.0"
+    pullPolicy:
   # Add additional environment variables to the gateway pod
   # e.g.
   # env:
@@ -126,18 +129,14 @@ gateway:
   # created for DaskCluster k8s resources by the controller.
   backend:
     # The image to use for both schedulers and workers.
-  #  image:
-  #    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-  #    tag: "dask_gateway_controller_v1"
-  #    pullPolicy: IfNotPresent
-    image:
-      name: ghcr.io/dask/dask-gateway
-      tag: "2024.1.0"
-      pullPolicy:
     #image:
-      #name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-worker
-      #tag: "dask-gateway-worker_v1"
+      #name: ghcr.io/dask/dask-gateway
+      #tag: "2024.1.0"
       #pullPolicy:
+    image:
+      name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-worker
+      tag: "dask-gateway-worker_v1"
+      pullPolicy:
     # Image pull secrets for a dask cluster's scheduler and worker pods
   #  imagePullSecrets: 
   #    - name: regcred

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -45,7 +45,7 @@ gateway:
 
   # Image pull secrets for gateway-server pod
   imagePullSecrets: 
-    - regcred
+    - "regcred"
 
   # Configuration for the gateway-server service
   service:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -45,7 +45,7 @@ gateway:
 
   # Image pull secrets for gateway-server pod
   imagePullSecrets: 
-    - "regcred"
+    - regcred
 
   # Configuration for the gateway-server service
   service:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -231,11 +231,9 @@ controller:
 
   # The image to use for the controller pod.
   image:
-    #name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
-    tag: dask_gateway_api_v1
-    #tag: "dask_gateway_controller_v1"
-    pullPolicy:
+    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
+    tag: "dask_gateway_controller_v1"
+    pullPolicy: IfNotPresent
   #image:
   #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
   #  tag: "dask_gateway_controller_v1"

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -46,7 +46,6 @@ gateway:
   # Image pull secrets for gateway-server pod
   imagePullSecrets: 
     name: regcred
-    existingSecret: ""
 
   # Configuration for the gateway-server service
   service:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -230,14 +230,14 @@ controller:
   k8sApiRateLimitBurst: 100
 
   # The image to use for the controller pod.
-  image:
-    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-    tag: "dask_gateway_controller_v1"
-    pullPolicy: IfNotPresent
   #image:
   #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
   #  tag: "dask_gateway_controller_v1"
   #  pullPolicy: IfNotPresent
+  image:
+    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
+    tag: dask_gateway_api_v1
+    pullPolicy: IfNotPresent
   imagePullSecrets: 
     - name: regcred
   # Settings for nodeSelector, affinity, and tolerations for the controller pods

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -231,8 +231,10 @@ controller:
 
   # The image to use for the controller pod.
   image:
-    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-    tag: "dask_gateway_controller_v1"
+    #name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
+    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
+    tag: dask_gateway_api_v1
+    #tag: "dask_gateway_controller_v1"
     pullPolicy:
   #image:
   #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -230,7 +230,8 @@ controller:
     name: registry1.dso.mil/ironbank/opensource/309theddge/dask_gateway_controller_v1 
     tag: "dask_gateway_controller_v1"
     pullPolicy: IfNotPresent
-
+  imagePullSecrets: 
+    - name: regcred
   # Settings for nodeSelector, affinity, and tolerations for the controller pods
   nodeSelector: {}
   affinity: {}

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -32,8 +32,8 @@ gateway:
 
   # The image to use for the dask-gateway-server pod (api pod)
   image:
-    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
-    tag: dask_gateway_api_v1
+    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-controller
+    tag: dask_gateway_controller_v1
     pullPolicy: IfNotPresent
 
   # Add additional environment variables to the gateway pod

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -44,7 +44,9 @@ gateway:
   env: []
 
   # Image pull secrets for gateway-server pod
-  imagePullSecrets: []
+  imagePullSecrets: 
+    name: regcred
+    existingSecret: ""
 
   # Configuration for the gateway-server service
   service:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -132,7 +132,7 @@ gateway:
   #    pullPolicy: IfNotPresent
     image:
       name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-worker
-      tag: "dask_gateway_worker_v1"
+      tag: "dask-gateway-worker_v1"
       pullPolicy:
     # Image pull secrets for a dask cluster's scheduler and worker pods
   #  imagePullSecrets: 

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -127,7 +127,7 @@ gateway:
   backend:
     # The image to use for both schedulers and workers.
     image:
-      name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller 
+      name: registry1.dso.mil/ironbank/opensource/309theddge/dask_gateway_controller_v1 
       tag: "dask_gateway_controller_v1"
       pullPolicy: IfNotPresent
 

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -34,7 +34,7 @@ gateway:
   image:
     name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
     tag: dask_gateway_api_v1
-    pullPolicy:
+    pullPolicy: IfNotPresent
 
   # Add additional environment variables to the gateway pod
   # e.g.
@@ -42,7 +42,7 @@ gateway:
   # - name: MYENV
   #   value: "my value"
   env: []
-
+  
   # Image pull secrets for gateway-server pod
   imagePullSecrets: 
     name: regcred

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -127,7 +127,7 @@ gateway:
   backend:
     # The image to use for both schedulers and workers.
     image:
-      name: registry1.dso.mil/ironbank/opensource/309theddge/dask_gateway_controller_v1 
+      name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller:dask_gateway_controller_v1 
       tag: "dask_gateway_controller_v1"
       pullPolicy: IfNotPresent
 
@@ -227,7 +227,7 @@ controller:
 
   # The image to use for the controller pod.
   image:
-    name: registry1.dso.mil/ironbank/opensource/309theddge/dask_gateway_controller_v1 
+    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller:dask_gateway_controller_v1
     tag: "dask_gateway_controller_v1"
     pullPolicy: IfNotPresent
   imagePullSecrets: 

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -45,7 +45,7 @@ gateway:
 
   # Image pull secrets for gateway-server pod
   imagePullSecrets: 
-    - regcred
+    - name: regcred
 
   # Configuration for the gateway-server service
   service:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -131,13 +131,14 @@ gateway:
   #    tag: "dask_gateway_controller_v1"
   #    pullPolicy: IfNotPresent
     image:
-      name: ghcr.io/dask/dask-gateway-server
-      tag: "2024.1.0"
+      name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-worker
+      tag: "dask_gateway_worker_v1"
       pullPolicy:
     # Image pull secrets for a dask cluster's scheduler and worker pods
   #  imagePullSecrets: 
   #    - name: regcred
-    imagePullSecrets: []
+    imagePullSecrets: 
+    - name: regcred
     # The namespace to launch dask clusters in. If not specified, defaults to
     # the same namespace the gateway is running in.
     namespace:
@@ -230,15 +231,15 @@ controller:
 
   # The image to use for the controller pod.
   image:
-    name: ghcr.io/dask/dask-gateway-server
-    tag: "2024.1.0"
+    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
+    tag: "dask_gateway_controller_v1"
     pullPolicy:
   #image:
   #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
   #  tag: "dask_gateway_controller_v1"
   #  pullPolicy: IfNotPresent
-  #imagePullSecrets: 
-  #  - name: regcred
+  imagePullSecrets: 
+    - name: regcred
   # Settings for nodeSelector, affinity, and tolerations for the controller pods
   nodeSelector: {}
   affinity: {}

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -32,8 +32,8 @@ gateway:
 
   # The image to use for the dask-gateway-server pod (api pod)
   image:
-    name: ghcr.io/dask/dask-gateway-server
-    tag: "2024.1.0"
+    name: registry1.dso.mil/ironbank/opensource
+    tag: "dask_gateway_api_v1"
     pullPolicy:
 
   # Add additional environment variables to the gateway pod

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -227,9 +227,9 @@ controller:
 
   # The image to use for the controller pod.
   image:
-    name: ghcr.io/dask/dask-gateway-server
-    tag: "2024.1.0"
-    pullPolicy:
+    name: registry1.dso.mil/ironbank/opensource/309theddge/dask_gateway_controller_v1 
+    tag: "dask_gateway_controller_v1"
+    pullPolicy: IfNotPresent
 
   # Settings for nodeSelector, affinity, and tolerations for the controller pods
   nodeSelector: {}

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -127,12 +127,13 @@ gateway:
   backend:
     # The image to use for both schedulers and workers.
     image:
-      name: ghcr.io/dask/dask-gateway
-      tag: "2024.1.0"
-      pullPolicy:
+      name: opensource/309theddge/dask-gateway-controller 
+      tag: "dask_gateway_controller_v1"
+      pullPolicy: IfNotPresent
 
     # Image pull secrets for a dask cluster's scheduler and worker pods
-    imagePullSecrets: []
+    imagePullSecrets: 
+      - name: regcred
 
     # The namespace to launch dask clusters in. If not specified, defaults to
     # the same namespace the gateway is running in.

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -127,7 +127,7 @@ gateway:
   backend:
     # The image to use for both schedulers and workers.
     image:
-      name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller:dask_gateway_controller_v1 
+      name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
       tag: "dask_gateway_controller_v1"
       pullPolicy: IfNotPresent
 
@@ -227,7 +227,7 @@ controller:
 
   # The image to use for the controller pod.
   image:
-    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller:dask_gateway_controller_v1
+    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
     tag: "dask_gateway_controller_v1"
     pullPolicy: IfNotPresent
   imagePullSecrets: 

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -137,7 +137,7 @@ gateway:
     # Image pull secrets for a dask cluster's scheduler and worker pods
   #  imagePullSecrets: 
   #    - name: regcred
-
+    imagePullSecrets: []
     # The namespace to launch dask clusters in. If not specified, defaults to
     # the same namespace the gateway is running in.
     namespace:

--- a/apps/dask-gateway/values.yaml
+++ b/apps/dask-gateway/values.yaml
@@ -230,14 +230,14 @@ controller:
   k8sApiRateLimitBurst: 100
 
   # The image to use for the controller pod.
-  #image:
-  #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
-  #  tag: "dask_gateway_controller_v1"
-  #  pullPolicy: IfNotPresent
   image:
-    name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
-    tag: dask_gateway_api_v1
+    name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller
+    tag: "dask_gateway_controller_v1"
     pullPolicy: IfNotPresent
+  #image:
+   # name: registry1.dso.mil/ironbank/opensource/309th/dask-gateway-api
+   # tag: dask_gateway_api_v1
+   # pullPolicy: IfNotPresent
 
   #image:
   #  name: registry1.dso.mil/ironbank/opensource/309theddge/dask-gateway-controller

--- a/opal-setup/values.yaml
+++ b/opal-setup/values.yaml
@@ -40,7 +40,7 @@ valuesFile: test-values.yaml
 
 source: &appSource
   url: "https://github.com/309thEDDGE/opal-helm.git"
-  targetRevision: "daskworker-node-management"
+  targetRevision: "dask-image-test"
 
 # Most of this is just propagating settings from above, but change as needed for your use case
 appValues:


### PR DESCRIPTION
This will be used to test the New IB images for the dask-gateway-api and the dask-gateway-controller.  the way to test this is to spin up a local instance of opal-helm and open a new jupyterhub notebook:

#cell1
from dask_gateway import Gateway
import time
from dask.distributed import Client
import dask.array as da
import os

gateway = Gateway(address=os.environ["DASK_GATEWAY_ADDRESS"], proxy_address=os.environ["DASK_GATEWAY_PROXY_ADDRESS"], auth="jupyterhub")
cluster = gateway.new_cluster()
cluster.adapt(minimum=2, maximum=10)

#cell2
client = Client(cluster)
client

Note: you may need to conda/pip install packages for this test to work.

After you have the client running you will be able to see the cluster information that will look like this:

> Dashboard: http://proxy-public/services/dask-gateway/clusters/opal.<randomnumber>/status 

you will have to change this URL to this: 
> https://opal-k8s.10.96.30.9.nip.io/services/dask-gateway/clusters/opal.<randomnumber>/status

# make sure to shut down the cluster
cluster.shutdown()
print('Cluster is shutdown')

You can also review the image repos here:
https://repo1.dso.mil/dsop/309theddge/dask-gateway-controller
https://repo1.dso.mil/dsop/309theddge/dask-gateway-api


You can also check the dask-gateway-controller / dask-gateway-api pods running in your k9s.

